### PR TITLE
fix: resolve 7 deployment issues for OCP cluster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,92 +1,73 @@
 # .env.example — copy to `.env`, fill in your values, then `source .env`
 # before running:
 #   - scripts/bootstrap-r53-delegation.sh
-#   - cd terraform && terraform apply        (TF_VAR_* below feed terraform/variables.tf)
-#   - cd terraform/prereqs && terraform apply
+#   - scripts/stamp-fqdn.sh              (stamps CLUSTER_FQDN into manifests)
+#   - cd terraform && terraform apply
 #
 # `.env` is .gitignored. Do not commit your filled version.
 
 ###############################################################################
-# AWS profiles
+# AWS profiles (must match ~/.aws/config profile names)
 ###############################################################################
 
-# Sandbox account — owns the cluster + the child zone (rhsummit.coderdemo.io).
-# This is where the cluster Terraform runs.
-export AWS_PROFILE_SANDBOX="sandbox"
+# Cluster account — owns the OCP cluster + child zone (rhsummit.coderdemo.io).
+export AWS_PROFILE_CLUSTER="aws-rh-openshift-demo-env"
 
-# Parent account — owns the parent zone (coderdemo.io). Leave empty if you
-# don't have direct access; bootstrap-r53-delegation.sh will emit a JSON
-# change-batch you can hand to whoever does (e.g., Greg).
-export AWS_PROFILE_PARENT=""
+# Parent account — owns the parent zone (coderdemo.io) in Route 53.
+# Used only by scripts/bootstrap-r53-delegation.sh to write the NS delegation.
+# Leave empty to get a JSON change-batch you can hand off.
+export AWS_PROFILE_PARENT="parent"
 
-# Default profile for `aws` / `terraform` / friends. Almost always the
-# sandbox profile — TF runs against it.
-export AWS_PROFILE="${AWS_PROFILE_SANDBOX}"
+# Default profile for `aws` / `terraform` / friends — the cluster account.
+export AWS_PROFILE="${AWS_PROFILE_CLUSTER}"
 export AWS_REGION="us-east-1"
 
 ###############################################################################
 # DNS — cross-account R53 subdomain delegation
 ###############################################################################
 
-# Parent zone (already exists in the parent account)
 export PARENT_ZONE="coderdemo.io"
-
-# Child zone — created by scripts/bootstrap-r53-delegation.sh in the
-# sandbox account, then delegated from the parent.
 export CHILD_ZONE="rhsummit.coderdemo.io"
 
-# Read by bootstrap-r53-delegation.sh as flag fallbacks
-export CHILD_PROFILE="${AWS_PROFILE_SANDBOX}"
+# bootstrap-r53-delegation.sh flag fallbacks
+export CHILD_PROFILE="${AWS_PROFILE_CLUSTER}"
 export PARENT_PROFILE="${AWS_PROFILE_PARENT}"
 
 ###############################################################################
-# Cluster Terraform inputs (terraform/variables.tf via TF_VAR_*)
+# Cluster FQDN — single source of truth
 #
-# These let you skip terraform/terraform.tfvars entirely. If you'd rather
-# use a tfvars file, see terraform/terraform.tfvars.example.
+# All manifests, Helm values, and scripts derive from these two values.
+# CLUSTER_FQDN = <cluster_name>.<base_domain>
+#
+# After changing these, run: ./scripts/stamp-fqdn.sh
 ###############################################################################
 
-# Domain — keep in sync with CHILD_ZONE above. The cluster FQDN becomes
-# <cluster_name>.<base_domain>, e.g., cluster.rhsummit.coderdemo.io.
-export TF_VAR_base_domain="${CHILD_ZONE}"
+export CLUSTER_NAME="cluster"
+export BASE_DOMAIN="${CHILD_ZONE}"
+export CLUSTER_FQDN="${CLUSTER_NAME}.${BASE_DOMAIN}"
+
+###############################################################################
+# Cluster Terraform inputs (terraform/variables.tf via TF_VAR_*)
+###############################################################################
+
+export TF_VAR_base_domain="${BASE_DOMAIN}"
 export TF_VAR_aws_region="${AWS_REGION}"
-export TF_VAR_cluster_name="cluster"
-export TF_VAR_owner_email="austen@coder.com"
+export TF_VAR_aws_profile="${AWS_PROFILE_CLUSTER}"
+export TF_VAR_cluster_name="${CLUSTER_NAME}"
+export TF_VAR_owner_email="you@example.com"
 
-# Red Hat partner pull-secret JSON — download from
-# https://console.redhat.com/openshift/install/pull-secret
 export TF_VAR_pull_secret_path="$HOME/.openshift/pull-secret.json"
-
-# SSH public key installed on OCP nodes for break-glass access
 export TF_VAR_ssh_pubkey_path="$HOME/.ssh/id_ed25519.pub"
-
-# Tool binaries (must be on PATH; override with full path if installed elsewhere).
-# openshift-install must be 4.21+ — get from
-# https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
 export TF_VAR_openshift_install_binary="openshift-install"
 export TF_VAR_oc_binary="oc"
 
-# Cluster sizing — defaults are the compact 3-node converged + 1 GPU shape:
-#
-#   3× m6i.4xlarge   converged control-plane / workers (compute.replicas: 0)
-#   1× g5.2xlarge    GPU node, hosts RHAIIS (vllm-cuda-rhel9)
-#
-# scripts/aws-quota-bootstrap.sh reads these to compute AWS Service Quota
-# needs; the cluster TF reads them to render install-config.yaml. Keep
-# them in sync with terraform/terraform.tfvars (or skip the tfvars file
-# entirely and rely only on this env).
+# Cluster sizing — compact 3-node converged + 1 GPU (default).
+# Uncomment to override defaults in terraform/variables.tf:
 # export TF_VAR_control_plane_count=3
 # export TF_VAR_control_plane_instance_type=m6i.4xlarge
 # export TF_VAR_worker_count=0
 # export TF_VAR_gpu_count=1
 # export TF_VAR_gpu_instance_type=g5.2xlarge
-# export TF_VAR_gpu_zone_index=0       # 0 = us-east-1a, 1 = us-east-1b, 2 = us-east-1c
-#
-# SNO (single-node, no HA, no GPU):
-# export TF_VAR_control_plane_count=1
-# export TF_VAR_control_plane_instance_type=m6i.8xlarge
-# export TF_VAR_worker_count=0
-# export TF_VAR_gpu_count=0
 
 # Coder version pin — bump only when a newer tagged RC ships.
 # export TF_VAR_coder_chart_version="2.33.0-rc.3"
@@ -96,48 +77,6 @@ export TF_VAR_oc_binary="oc"
 # Account-level prereqs Terraform (terraform/prereqs/variables.tf)
 ###############################################################################
 
-# Whether the prereqs TF should manage the parent zone. Almost always FALSE
-# in cross-account setups — the parent zone is owned by Account A and the
-# delegation is handled by scripts/bootstrap-r53-delegation.sh.
 export TF_VAR_manage_hosted_zone="false"
-
-# scripts/aws-quota-bootstrap.sh consumes the cluster sizing TF_VAR_* set
-# above to compute needed quotas. No extra env vars required, but you can
-# override its tracker file path:
-# export TRACKER_FILE="$HOME/.aws-quota-bootstrap.json"
-
-# Whether the prereqs TF should create a dedicated installer IAM user with
-# admin perms. Set false if you'll use your existing AWS_PROFILE creds.
 export TF_VAR_create_installer_iam="false"
-
-# Quota-increase requests via Service Quotas API — leave false unless you
-# know you need it; you can request manually via the AWS console.
 export TF_VAR_request_quota_increases="false"
-
-###############################################################################
-# Coder (filled in AFTER `terraform apply` finishes — needed for GH Actions)
-###############################################################################
-
-# Once the cluster is up, Coder is reachable at https://coder.apps.<base_domain>.
-# Log in as kubeadmin (password in ./.cluster/auth/kubeadmin-password), create
-# the first user, generate a session token, then:
-#
-#   gh secret set CODER_URL --body "https://coder.apps.cluster.${CHILD_ZONE}"
-#   gh secret set CODER_SESSION_TOKEN --body "<token from coder tokens create>"
-#
-# Optional GH var (only if you fork into a different GH org):
-#   gh variable set IMAGE_REGISTRY --body "ghcr.io/<your-org>/<repo>"
-#
-# These are not in this env file — they go into the GH repo itself, not your
-# local shell.
-
-###############################################################################
-# Bedrock model access (one-time, manual, AWS console)
-###############################################################################
-
-# AWS retired the per-model approval page in late 2025. Serverless models
-# on Bedrock now auto-enable on first invocation. First-time Anthropic
-# users are prompted for a one-page use-case form on first open / first
-# invoke — fill it in once, approval is minutes:
-#   open "https://${AWS_REGION}.console.aws.amazon.com/bedrock/home?region=${AWS_REGION}#/foundation-models"
-# Or smoke-test with: aws bedrock-runtime invoke-model --model-id anthropic.claude-sonnet-4-...

--- a/.github/workflows/push-templates.yml
+++ b/.github/workflows/push-templates.yml
@@ -51,9 +51,10 @@ jobs:
           cd coder-templates/${{ matrix.template }}
           coder templates push ${{ matrix.template }} \
             --directory . \
+            --create \
             --variable namespace="$NAMESPACE" \
             --variable image_registry="$IMAGE_REGISTRY" \
-            --variable ai_gateway_url="$AI_GATEWAY_URL" \
+            --variable ai_gateway_url="${AI_GATEWAY_URL:-http://coder.coder.svc.cluster.local:7080/v1}" \
             --yes \
             --message "GH Actions push from ${{ github.sha }}"
 

--- a/coder-templates/openshift-ai-gov/config.yaml
+++ b/coder-templates/openshift-ai-gov/config.yaml
@@ -48,10 +48,9 @@ allowlist:
   - "domain=ghcr.io"
   - "domain=*.ghcr.io"
 
-# nsjail uses Linux network namespaces; requires CAP_NET_ADMIN on the pod
-# (configurable via OCP SCC). Strong bypass resistance.
-# Switch to landjail only if you're on a kernel ≥ 6.7 (RHEL 9 / OCP 4.21
-# nodes are 5.14 — landjail will fail at runtime).
+# nsjail uses Linux network namespaces for process isolation. Requires
+# CAP_NET_ADMIN on the workspace pod — granted via the custom SCC
+# `coder-workspace-nsjail` (see manifests/coder/scc-nsjail.yaml).
 jail_type: nsjail
 
 log_dir: /tmp/boundary_logs

--- a/coder-templates/openshift-ai-gov/main.tf
+++ b/coder-templates/openshift-ai-gov/main.tf
@@ -225,13 +225,27 @@ resource "kubernetes_pod" "main" {
   }
 
   spec {
-    restart_policy = "Always"
+    restart_policy       = "Always"
+    service_account_name = "coder-workspace"
 
     container {
       name              = "dev"
       image             = "${var.image_registry}/${data.coder_parameter.image.value}"
       image_pull_policy = "Always"
       command           = ["sh", "-c", coder_agent.main.init_script]
+
+      security_context {
+        run_as_non_root            = true
+        run_as_user                = 1000
+        allow_privilege_escalation = false
+        capabilities {
+          add  = ["NET_ADMIN"]
+          drop = ["ALL"]
+        }
+        seccomp_profile {
+          type = "RuntimeDefault"
+        }
+      }
 
       env {
         name  = "CODER_AGENT_TOKEN"

--- a/manifests/coder/namespace-workspaces.yaml
+++ b/manifests/coder/namespace-workspaces.yaml
@@ -1,0 +1,13 @@
+# Namespace for Coder workspace pods.
+#
+# The workspace template (coder-templates/openshift-ai-gov/main.tf) deploys
+# pods into this namespace. Created here via GitOps so it exists before any
+# template push or workspace creation.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coder-workspaces
+  labels:
+    app.kubernetes.io/part-of: coder-aigov-demo
+  annotations:
+    description: "Coder workspace pods land here."

--- a/manifests/coder/scc-nsjail.yaml
+++ b/manifests/coder/scc-nsjail.yaml
@@ -1,0 +1,75 @@
+# Custom SCC for Coder workspace pods running Agent Firewall (nsjail).
+#
+# nsjail requires CAP_NET_ADMIN to create network namespaces for process
+# isolation. This SCC extends restricted-v2 with only that one capability.
+#
+# Bound to the `coder-workspace` ServiceAccount in the `coder-workspaces`
+# namespace via the ClusterRoleBinding below.
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: coder-workspace-nsjail
+  annotations:
+    description: "restricted-v2 + NET_ADMIN for Agent Firewall nsjail"
+# Start from restricted-v2 defaults
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - NET_ADMIN
+defaultAddCapabilities: []
+requiredDropCapabilities:
+  - ALL
+fsGroup:
+  type: MustRunAs
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+priority: 10
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coder-workspace
+  namespace: coder-workspaces
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coder-workspace-nsjail-scc
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["coder-workspace-nsjail"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coder-workspace-nsjail-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coder-workspace-nsjail-scc
+subjects:
+  - kind: ServiceAccount
+    name: coder-workspace
+    namespace: coder-workspaces

--- a/manifests/rhaiis/vllm-deployment.yaml
+++ b/manifests/rhaiis/vllm-deployment.yaml
@@ -61,6 +61,10 @@ spec:
       # drivers are running.
       nodeSelector:
         nvidia.com/gpu.present: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: vllm
           # CUDA-enabled RHAIIS image. `latest` per RH Summit 2026 demo

--- a/scripts/stamp-fqdn.sh
+++ b/scripts/stamp-fqdn.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# scripts/stamp-fqdn.sh — Replace FQDN placeholders in manifests with the
+# value from .env. Run after changing CLUSTER_NAME or BASE_DOMAIN.
+#
+# Usage:
+#   source .env && ./scripts/stamp-fqdn.sh
+#
+# Idempotent — safe to re-run.
+
+set -euo pipefail
+
+: "${CLUSTER_FQDN:?ERROR: CLUSTER_FQDN not set. Run: source .env}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APPS_FQDN="apps.${CLUSTER_FQDN}"
+
+echo "Stamping FQDN: ${CLUSTER_FQDN} (apps: ${APPS_FQDN})"
+
+# Pattern: any *.apps.<something>.coderdemo.io or apps.<something>.coderdemo.io
+# We replace the apps domain portion in all relevant files.
+find "$REPO_ROOT" \( -path '*/.git' -prune \) -o \
+  \( -name '*.yaml' -o -name '*.yml' \) -print0 |
+  xargs -0 sed -i '' \
+    -e "s|apps\.[a-z0-9.-]*\.coderdemo\.io|${APPS_FQDN}|g"
+
+echo "Done. Verify with: grep -r '${APPS_FQDN}' manifests/ gitops/ coder-templates/"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -194,7 +194,8 @@ resource "null_resource" "openshift_install" {
     command = <<-EOT
       set -euo pipefail
       echo "Running openshift-install create cluster (this takes 30–45 min)..."
-      ${var.openshift_install_binary} create cluster \
+      # RH docs: installer waits up to 30m API + 30m bootstrap + 30m init + 10m console.
+      timeout 3600 ${var.openshift_install_binary} create cluster \
         --dir="${var.install_dir}" \
         --log-level=info
     EOT

--- a/terraform/prereqs/terraform.tfvars.example
+++ b/terraform/prereqs/terraform.tfvars.example
@@ -1,14 +1,14 @@
 # Copy to terraform.tfvars and fill in.
 
 aws_region   = "us-east-1"
-aws_profile  = null            # null = default credential chain
+aws_profile  = "aws-rh-openshift-demo-env"   # cluster/sandbox account
 owner_email  = "austen@coder.com"
 
 cluster_name = "cluster"   # MUST match cluster TF
 
 # Route 53
 manage_hosted_zone = true
-base_domain        = "rh.coderdemo.io"   # YOUR public domain
+base_domain        = "rhsummit.coderdemo.io"   # child zone in sandbox account
 
 # IAM
 create_installer_iam = true

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -8,7 +8,7 @@
 # VPC is BYO and created in <region>{a,b,c}; if you change region, change
 # the prereqs/terraform.tfvars region to match.
 aws_region   = "us-east-1"
-aws_profile  = null            # null = default credential chain
+aws_profile  = "aws-rh-openshift-demo-env"   # cluster account
 owner_email  = "austen@coder.com"
 
 ###############################################################################
@@ -16,7 +16,7 @@ owner_email  = "austen@coder.com"
 ###############################################################################
 
 cluster_name             = "cluster"
-base_domain              = "rh.coderdemo.io"   # YOUR public Route 53 zone
+base_domain              = "rhsummit.coderdemo.io"   # YOUR public Route 53 zone
 openshift_version        = "stable-4.21"
 openshift_install_binary = "openshift-install" # path to 4.21+ binary
 oc_binary                = "oc"


### PR DESCRIPTION
- FQDN: add CLUSTER_FQDN to .env, create scripts/stamp-fqdn.sh, align tfvars
- Namespace: add coder-workspaces namespace manifest (GitOps wave 2)
- nsjail: add custom SCC (NET_ADMIN), ServiceAccount, security_context on pod
- AWS profiles: align to aws-rh-openshift-demo-env + parent
- Timeout: wrap openshift-install with 60min timeout (Linux)
- Template push: add --create flag, fix empty AI_GATEWAY_URL fallback
- RHAIIS: add nvidia.com/gpu toleration for GPU taint